### PR TITLE
refactor: Using public dynamic methods instead of static class constants

### DIFF
--- a/src/fastapi_oauth2/core.py
+++ b/src/fastapi_oauth2/core.py
@@ -64,8 +64,8 @@ class OAuth2Core:
         self.provider = client.backend.name
         self.redirect_uri = client.redirect_uri
         self.backend = client.backend(OAuth2Strategy())
-        self._authorization_endpoint = client.backend.AUTHORIZATION_URL
-        self._token_endpoint = client.backend.ACCESS_TOKEN_URL
+        self._authorization_endpoint = self.backend.authorization_url()
+        self._token_endpoint = self.backend.access_token_url()
         self._oauth_client = WebApplicationClient(self.client_id)
 
     @property


### PR DESCRIPTION
### Motivation:

<!-- These changes are done because of #N issue... It fixes ... -->

Some backend implementations use the base methods `authorization_url` and `access_token_url`  instead of the constant settings.

This PR makes a minimal change to support using method instead of class constants, which can be more flexible in some cases (for example the `Auth0OAuth2`which use the base domain to compound these urls)

### All Submissions:

* [ ] Have you followed the guidelines in our [Contributing](./CONTRIBUTING.md) document?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

### Changes to Core Features:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you updated the documentation related to the changes you have made?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?
