### PR TITLE
GH-37: Fix `invalid_client` KOE010 issue

### DIFF
--- a/src/fastapi_oauth2/core.py
+++ b/src/fastapi_oauth2/core.py
@@ -107,7 +107,11 @@ class OAuth2Core:
         scheme = "http" if request.auth.http else "https"
         authorization_response = re.sub(r"^https?", scheme, str(request.url))
 
-        oauth2_query_params = dict(redirect_url=redirect_uri, authorization_response=authorization_response)
+        oauth2_query_params = dict(
+            redirect_url=redirect_uri,
+            client_secret=self.client_secret,
+            authorization_response=authorization_response,
+        )
         oauth2_query_params.update(request.query_params)
 
         token_url, headers, content = self._oauth_client.prepare_token_request(


### PR DESCRIPTION
### Motivation:

This PR fixes the #37 issue reported by @kkh-147-17-3. A few OAuth providers require `client_secret` on the `/token` endpoint, and `httpx.AsyncClient` basic auth does not provide it appropriately.

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing](./CONTRIBUTING.md) document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you updated the documentation related to the changes you have made?
* [ ] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
