### PR TITLE
Fix "Cannot supply multiple client credentials." error for Okta users

### DIFF
--- a/src/fastapi_oauth2/core.py
+++ b/src/fastapi_oauth2/core.py
@@ -124,6 +124,9 @@ class OAuth2Core:
         async with httpx.AsyncClient(auth=auth, **httpx_client_args) as session:
             try:
                 response = await session.post(token_url, headers=headers, content=content)
+                if response.status_code == 401:
+                    content = re.sub(r"client_id=[^&]+", "", content)
+                    response = await session.post(token_url, headers=headers, content=content)
                 self._oauth_client.parse_request_body_response(json.dumps(response.json()))
                 return self.standardize(self.backend.user_data(self.access_token))
             except (OAuth2Error, httpx.HTTPError) as e:


### PR DESCRIPTION
### Motivation:

Fixed "Cannot supply multiple client credentials." error for Okta users. This error was found during the investigation in the scope of the #45 discussion. The error occurred because of the Okta-specific implementation of OAuth2 and was fixed based on the [discourse](https://devforum.okta.com/t/error-cannot-supply-multiple-client-credentials/10307) conversation.

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing](./CONTRIBUTING.md) document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you updated the documentation related to the changes you have made?
* [ ] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
